### PR TITLE
x86: Support ioports.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ exclude = ["docs", ".idea"]
 [target.'cfg(all(target_arch = "x86_64", target_os = "none"))'.dependencies]
 x86_64 = "0.11"
 raw-cpuid = "8.0"
+
+[features]
+default = []
+# This requires allocating a 64K consecutive memory block.
+ioport_bitmap = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trapframe"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Runji Wang <wangrunji0408@163.com>", "Jiajie Chen <c@jia.je>"]
 edition = "2018"
 description = "Handle Trap Frame across kernel and user space on multiple ISAs."

--- a/src/arch/x86_64/gdt.rs
+++ b/src/arch/x86_64/gdt.rs
@@ -28,13 +28,12 @@ impl TaskStateSegmentPortBitmap {
     pub const PORT_BITMAP_OFFSET: usize = size_of::<TaskStateSegment>();
 
     fn new() -> Self {
-        const ALLOW_ALL: u8 = 0;
+        const DENY_ALL: u8 = !0;
         Self {
             tss: TaskStateSegment::new(),
-            port_bitmap: [ALLOW_ALL; 1 + Self::BITMAP_VALID_SIZE]
+            port_bitmap: [DENY_ALL; 1 + Self::BITMAP_VALID_SIZE]
         }
     }
-
 }
 
 pub fn gsbase_to_bitmap<'a>(gsbase: u64) -> &'a mut [u8] {

--- a/src/arch/x86_64/gdt.rs
+++ b/src/arch/x86_64/gdt.rs
@@ -39,7 +39,8 @@ impl TaskStateSegmentPortBitmap {
 }
 
 #[cfg(feature = "ioport_bitmap")]
-pub fn gsbase_to_bitmap<'a>(gsbase: u64) -> &'a mut [u8] {
+pub fn gsbase_to_bitmap<'a>() -> &'a mut [u8] {
+    let gsbase = unsafe { GsBase::MSR.read() };
     unsafe {
         from_raw_parts_mut(
             (gsbase as usize + TaskStateSegmentPortBitmap::PORT_BITMAP_OFFSET) as *mut u8,

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -14,8 +14,6 @@ pub use fncall::syscall_fn_entry;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
 pub use trap::TrapFrame;
 
-pub use gdt::gsbase_to_bitmap;
-
 /// Initialize interrupt handling on x86_64.
 ///
 /// # Safety
@@ -127,6 +125,7 @@ impl UserContext {
 
     /// Get ioport bitmap, called after gdt::init().
     /// Return true for deny, false for allow.
+    #[cfg(any(target_os = "none", target_os = "uefi"))]
     pub fn get_ioport_bitmap(&self, port: u16) -> bool {
         use crate::arch::gdt::TaskStateSegmentPortBitmap;
         let tss = unsafe { *(self.general.gsbase as *mut TaskStateSegmentPortBitmap) };
@@ -136,6 +135,7 @@ impl UserContext {
     }
 
     /// Set ioport bitmap, called after gdt::init().
+    #[cfg(any(target_os = "none", target_os = "uefi"))]
     pub fn set_ioport_bitmap(&mut self, port: u16, deny: bool) {
         use crate::arch::gdt::TaskStateSegmentPortBitmap;
         let mut tss = unsafe { *(self.general.gsbase as *mut TaskStateSegmentPortBitmap) };

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -14,6 +14,8 @@ pub use fncall::syscall_fn_entry;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
 pub use trap::TrapFrame;
 
+pub use gdt::gsbase_to_bitmap;
+
 /// Initialize interrupt handling on x86_64.
 ///
 /// # Safety


### PR DESCRIPTION
Right after TSS, a 65536-bit array is allocated, which is used as the bitmap controlling port I/O.

* Add feature switch: `feature = "ioport_bitmap"`, disabled by default.
* `gsbase_to_ioport` converts the gsbase (that is pointing to current TSS) to the ioport bitmap.
* In the bitmap, 0 stands for port access allowed, while 1 stands for port access denied.

HACKS:
* Hacking TSS limit, because x86_64 assumes no io/bitmap is present. 