### PR TITLE
Fix build on latest nightly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["docs", ".idea"]
 [dependencies]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = "0.12"
+x86_64 = "0.13"
 raw-cpuid = "8.0"
 
 [features]

--- a/src/arch/x86_64/idt.rs
+++ b/src/arch/x86_64/idt.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use x86_64::structures::idt::*;
 use x86_64::structures::DescriptorTablePointer;
-use x86_64::PrivilegeLevel;
+use x86_64::{PrivilegeLevel, VirtAddr};
 
 pub fn init() {
     extern "C" {
@@ -27,7 +27,10 @@ pub fn init() {
 #[allow(dead_code)]
 #[inline]
 fn sidt() -> DescriptorTablePointer {
-    let mut dtp = DescriptorTablePointer { limit: 0, base: 0 };
+    let mut dtp = DescriptorTablePointer {
+        limit: 0,
+        base: VirtAddr::zero(),
+    };
     unsafe {
         asm!("sidt [{}]", in(reg) &mut dtp);
     }


### PR DESCRIPTION
We need to use the newer `x86_64` crate as that fixes a compilation
error due to a rustc feature having been removed.