### PR TITLE
Fix asm and global_asm macros

### DIFF
--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -8,6 +8,7 @@ extern crate opensbi_rt;
 use riscv::register::scause::{Exception as E, Scause, Trap};
 use riscv::register::{scause, stval};
 use trapframe::{GeneralRegs, TrapFrame, UserContext};
+use core::arch::asm;
 
 #[no_mangle]
 extern "C" fn main() {

--- a/examples/uefi/src/main.rs
+++ b/examples/uefi/src/main.rs
@@ -14,6 +14,7 @@ use trapframe::{GeneralRegs, TrapFrame, UserContext};
 use uefi::prelude::*;
 use x86_64::registers::control::*;
 use x86_64::structures::paging::{PageTable, PageTableFlags};
+use core::arch::asm;
 
 #[entry]
 fn efi_main(_image: Handle, st: SystemTable<Boot>) -> uefi::Status {

--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -8,6 +8,7 @@
 //! Because we will store values in their pthread structure.
 
 use super::UserContext;
+use core::arch::global_asm;
 
 global_asm!(include_str!("fncall.S"));
 
@@ -41,6 +42,7 @@ impl UserContext {
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use core::arch::global_asm;
 
     // Mock user program to dump registers at stack.
     global_asm!(

--- a/src/arch/aarch64/trap.rs
+++ b/src/arch/aarch64/trap.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::arch::{asm, global_asm};
 
 global_asm!(include_str!("trap.S"));
 

--- a/src/arch/mipsel/trap.rs
+++ b/src/arch/mipsel/trap.rs
@@ -1,3 +1,5 @@
+use core::arch::{asm, global_asm};
+
 global_asm!(include_str!("trap.S"));
 
 /// Initialize interrupt handling for the current HART.
@@ -11,7 +13,10 @@ global_asm!(include_str!("trap.S"));
 /// You **MUST NOT** modify these registers later.
 pub unsafe fn init() {
     // Set cp0 ebase(15, 1) register to trap entry
-    llvm_asm!("mtc0 $0, $$15, 1":: "r"(trap_entry as usize) :: "volatile");
+    asm!(
+        "mtc0 {trap_entry}, $15, 1",
+        trap_entry = in(reg) trap_entry,
+    );
 }
 
 #[no_mangle]

--- a/src/arch/riscv/trap.rs
+++ b/src/arch/riscv/trap.rs
@@ -1,3 +1,5 @@
+use core::arch::{asm, global_asm};
+
 #[cfg(target_arch = "riscv32")]
 global_asm!(
     r"

--- a/src/arch/x86_64/fncall.rs
+++ b/src/arch/x86_64/fncall.rs
@@ -8,6 +8,7 @@
 //! Because we will store values in their pthread structure.
 
 use super::UserContext;
+use core::arch::global_asm;
 
 extern "sysv64" {
     /// The syscall entry of function call.
@@ -230,6 +231,7 @@ syscall_fn_return:
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use core::arch::global_asm;
 
     #[cfg(target_os = "macos")]
     global_asm!(".set _dump_registers, dump_registers");

--- a/src/arch/x86_64/gdt.rs
+++ b/src/arch/x86_64/gdt.rs
@@ -2,6 +2,7 @@
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::arch::asm;
 use core::mem::size_of;
 
 use x86_64::instructions::tables::{lgdt, load_tss};

--- a/src/arch/x86_64/idt.rs
+++ b/src/arch/x86_64/idt.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::arch::asm;
 use x86_64::structures::idt::*;
 use x86_64::structures::DescriptorTablePointer;
 use x86_64::{PrivilegeLevel, VirtAddr};

--- a/src/arch/x86_64/syscall.rs
+++ b/src/arch/x86_64/syscall.rs
@@ -1,4 +1,5 @@
 use super::UserContext;
+use core::arch::global_asm;
 use x86_64::registers::model_specific::{Efer, EferFlags, LStar, SFMask};
 use x86_64::registers::rflags::RFlags;
 use x86_64::VirtAddr;

--- a/src/arch/x86_64/trap.rs
+++ b/src/arch/x86_64/trap.rs
@@ -1,3 +1,5 @@
+use core::arch::global_asm;
+
 global_asm!(include_str!("trap.S"));
 global_asm!(include_str!(concat!(env!("OUT_DIR"), "/vector.S")));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
-#![feature(llvm_asm, asm, global_asm, linkage)]
+#![feature(linkage)]
 #![deny(warnings)]
+#![cfg_attr(target_arch = "mips", feature(asm_experimental_arch))]
 
 extern crate alloc;
 


### PR DESCRIPTION
The macros are now namespaced:
https://github.com/rust-lang/rust/issues/84019