### PR TITLE
fix(riscv): don't split stateful assembly directives across global_asm instances

### DIFF
--- a/src/arch/riscv/trap.rs
+++ b/src/arch/riscv/trap.rs
@@ -10,7 +10,8 @@ global_asm!(
     .macro STORE_SP a1, a2
         sw \a1, \a2*XLENB(sp)
     .endm
-"
+",
+    include_str!("trap.S")
 );
 #[cfg(target_arch = "riscv64")]
 global_asm!(
@@ -22,10 +23,9 @@ global_asm!(
     .macro STORE_SP a1, a2
         sd \a1, \a2*XLENB(sp)
     .endm
-"
+",
+    include_str!("trap.S")
 );
-
-global_asm!(include_str!("trap.S"));
 
 /// Initialize interrupt handling for the current HART.
 ///


### PR DESCRIPTION
Relying on stateful directives to persist across inline assembly instances is forbidden: https://doc.rust-lang.org/reference/inline-assembly.html#r-asm.directives.stateful

Without this patch, in some scenarios, trapframe fails to compile, since the macros `XLENB`, `LOAD_SP`, and `STORE_SP` may not be available:

```bash
error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
   |
note: instantiated into assembly here
  --> <inline asm>:17:18
   |
17 |     addi sp, sp, -34 * XLENB
   |                  ^

error: unrecognized instruction mnemonic
   |
note: instantiated into assembly here
  --> <inline asm>:21:5
   |
21 |     STORE_SP x1, 1
   |     ^
...
error: could not compile `trapframe` (lib) due to 99 previous errors
```