### PR TITLE
fix(riscv): function_casts_as_integer

### DIFF
--- a/src/arch/riscv/trap.rs
+++ b/src/arch/riscv/trap.rs
@@ -41,7 +41,7 @@ pub unsafe fn init() {
     // presently executing in the kernel
     asm!("csrw sscratch, zero");
     // Set the exception vector address
-    asm!("csrw stvec, {}", in(reg) trap_entry as usize);
+    asm!("csrw stvec, {}", in(reg) trap_entry);
 }
 
 #[no_mangle]


### PR DESCRIPTION
```console
$ cargo build --target riscv64gc-unknown-none-elf
   Compiling trapframe v0.10.1 (/Users/mkroening/devel/trapframe-rs)
error: direct cast of function item into an integer
  --> src/arch/riscv/trap.rs:44:47
   |
44 |     asm!("csrw stvec, {}", in(reg) trap_entry as usize);
   |                                               ^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:3:9
   |
 3 | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(function_casts_as_integer)]` implied by `#[deny(warnings)]`
help: first cast to a pointer `as *const ()`
   |
44 |     asm!("csrw stvec, {}", in(reg) trap_entry as *const () as usize);
   |                                               ++++++++++++

error: could not compile `trapframe` (lib) due to 1 previous error
```