### PR TITLE
fix(riscv): allow far away `trap_handler`

### DIFF
--- a/src/arch/riscv/trap.S
+++ b/src/arch/riscv/trap.S
@@ -62,7 +62,7 @@ trap_from_user:
 end_trap_from_kernel:
     mv a0, sp               # first arg is TrapFrame
     la ra, trap_return      # set return address
-    j trap_handler
+    tail trap_handler
 
 end_trap_from_user:
     # load callee-saved registers


### PR DESCRIPTION
In Hermit, we can sometimes run into this issue:

```console
rust-lld: error: libhermit.rlib(trapframe.o):(.text+0x6e):
  relocation R_RISCV_JAL out of range: -1163894 is not in [-1048576, 1048575];
  references 'trap_handler'
```

Reproducing this is very hard. Even just switching from crates.io to a git dependency with the same source code influences the linking order enough to make the issue disappear. To make it disappear for good (hopefully), this PR replaces the near jump (`j`) with a far tail call (`tail`).