### PR TITLE
fix(x86_64): clear direction flag on trap entry

### DIFF
--- a/src/arch/x86_64/syscall.S
+++ b/src/arch/x86_64/syscall.S
@@ -103,6 +103,9 @@ syscall_entry:
 
 .global trap_syscall_entry
 trap_syscall_entry:
+    # Interrupts preserve DF, but the SysV ABI requires it to be clear when
+    # returning to Rust. The original value is already saved in rflags.
+    cld
     push r15
     push r14
     push r13

--- a/src/arch/x86_64/trap.S
+++ b/src/arch/x86_64/trap.S
@@ -60,6 +60,9 @@ __from_kernel:
     push rbx
     push rax
 
+    # The interrupted context may have DF set. The SysV ABI requires it to be
+    # clear before entering the Rust trap handler.
+    cld
     mov rdi, rsp
     call trap_handler
 


### PR DESCRIPTION
## Summary

- clear DF before calling the Rust trap handler for kernel traps
- clear DF on the common user trap/syscall path before returning to Rust
- preserve the interrupted context's original RFLAGS for `iretq`/`sysretq`

## Rationale

Interrupt entry preserves DF, while the x86-64 SysV ABI requires DF to be clear at function boundaries. Without an explicit `cld`, Rust code reached from a trap can run with DF set.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo build --manifest-path examples/uefi/Cargo.toml --target x86_64-unknown-uefi`
- `git diff --check`

Closes #15