### PR TITLE
fix(x86_64): use RIP-relative segment selector loads

### DIFF
--- a/src/arch/x86_64/syscall.S
+++ b/src/arch/x86_64/syscall.S
@@ -57,10 +57,10 @@ syscall_return:
     je sysret
 iret:
     # construct trap frame
-    push [USER_SS]          # push ss
+    push [rip + USER_SS]    # push ss
     push [rsp - 8*8]        # push rsp
     push [rsp + 3*8]        # push rflags
-    push [USER_CS]          # push cs
+    push [rip + USER_CS]    # push cs
     push [rsp + 4*8]        # push rip
 
     iretq


### PR DESCRIPTION
## Summary

Use RIP-relative addressing when loading `USER_SS` and `USER_CS` in the syscall return path.

The previous operands generate `R_X86_64_32S` absolute relocations. When trapframe is linked into a high-half kernel, the selector symbols are outside the signed 32-bit range and `rust-lld` rejects the image. RIP-relative operands generate relocations suitable for symbols located alongside the code.

## Verification

- `cargo +stable check --offline`
- zCore x86_64 high-half kernel build with Rust nightly-2026-09-01