### PR TITLE
Document all supported trapframe targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Ben Pig Chu <benpichu@gmail.com>",
 ]
 edition = "2024"
-description = "Handle Trap Frame across kernel and user space on multiple ISAs."
+description = "Cross user/kernel boundaries with function-like context switching on multiple ISAs."
 homepage = "https://github.com/rcore-os/trapframe-rs"
 documentation = "https://docs.rs/trapframe"
 readme = "README.md"
@@ -17,6 +17,18 @@ categories = ["no-std", "embedded"]
 license = "MIT"
 repository = "https://github.com/rcore-os/trapframe-rs"
 exclude = ["docs", ".idea"]
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = [
+    "x86_64-apple-darwin",
+    "x86_64-unknown-none",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-none-softfloat",
+    "riscv32imac-unknown-none-elf",
+    "riscv64imac-unknown-none-elf",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,126 @@
-# TrapFrame-rs
+# trapframe-rs
 
 [![Crate](https://img.shields.io/crates/v/trapframe.svg)](https://crates.io/crates/trapframe)
 [![Docs](https://docs.rs/trapframe/badge.svg)](https://docs.rs/trapframe)
 [![Actions Status](https://github.com/rcore-os/trapframe-rs/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/rcore-os/trapframe-rs/actions/workflows/main.yml?query=branch%3Amain)
 
-Handle Trap Frame across kernel and user space on multiple ISAs.
+`trapframe-rs` makes it easy to cross the boundary between kernel space and
+user space. It packages the architecture-specific register save, privilege
+transition, and trap return sequence into a kernel-side function call.
 
-Supported ISA: x86_64, aarch64, riscv32, riscv64, mipsel
+From the kernel's point of view, running user code looks like this:
 
-## Example
+```text
+prepare UserContext -> context.run() -> user code executes
+                              ^              |
+                              |              | syscall, exception, or interrupt
+                              +--------------+
+                         context.run() returns
+```
 
-### Go to user space
+When `run()` returns, the same `UserContext` contains the user's latest
+registers and trap state. The kernel can inspect the event, update registers,
+and call `run()` again to resume execution.
+
+The crate is `no_std` and supports x86-64, AArch64, RISC-V 32/64, and
+little-endian MIPS.
+
+## Bare-metal usage
+
+Initialize the architecture's trap entry once, construct a user context, and
+run it from the kernel:
 
 ```rust
-use trapframe::{UserContext, GeneralRegs};
+use trapframe::{GeneralRegs, UserContext};
 
-fn kernel_thread() {
-    // initialize trap handling
-    unsafe {
-        trapframe::init();
-    }
-    // construct a user space context, set registers
-    let mut context = UserContext {
-        general: GeneralRegs {
-            rip: 0x1000,
-            rsp: 0x10000,
-            ..Default::default()
-        },
+unsafe {
+    // Installs architecture-specific exception and syscall entry points.
+    trapframe::init();
+}
+
+let mut context = UserContext {
+    general: GeneralRegs {
+        // x86-64 example; register names vary by architecture.
+        rip: 0x1000,
+        rsp: 0x10_000,
         ..Default::default()
-    };
-    // go to user space with the context
+    },
+    ..Default::default()
+};
+
+loop {
     context.run();
-    // come back from user space, maybe syscall or trap
-    println!("back from user: {:#x?}", context);
-    // check the context and handle the trap
+
     match context.trap_num {
-        0x3 => println!("breakpoint"),
-        0xd => println!("general protection fault"),
-        0x100 => println!("syscall: id={}", context.general.rax),
-        ...
+        3 => {
+            // Breakpoint: advance past the instruction and resume.
+            context.general.rip += 1;
+        }
+        0x100 => {
+            let syscall_number = context.get_syscall_num();
+            let arguments = context.get_syscall_args();
+            let result = handle_syscall(syscall_number, arguments);
+            context.set_syscall_ret(result);
+        }
+        trap => panic!("unhandled user trap: {trap:#x}"),
     }
 }
 ```
 
-### Handle kernel trap
+The precise fields that report a trap are architecture-specific. See the
+[API documentation](https://docs.rs/trapframe) for the target you are building.
+
+## Kernel traps
+
+On bare-metal targets, define the `trap_handler` symbol expected by the assembly
+entry code. The handler receives a mutable architecture-specific `TrapFrame`:
 
 ```rust
 use trapframe::TrapFrame;
 
-#[unsafe(no_mangle)] // export a function 'trap_handler'
-extern "sysv64" fn trap_handler(tf: &mut TrapFrame) {
-    match tf.trap_num {
-        0x3 => {
-            println!("TRAP: Breakpoint");
-            tf.rip += 1;
-        }
-        _ => panic!("TRAP: {:#x?}", tf),
-    }
+#[unsafe(no_mangle)]
+extern "sysv64" fn trap_handler(frame: &mut TrapFrame) {
+    log::trace!("kernel trap: {frame:#x?}");
+    // Inspect or modify the saved registers before returning from the trap.
 }
 ```
 
-### More examples
+The required ABI is architecture-specific; the other architectures use
+`extern "C"`.
 
-* [x86_64](./examples/uefi)
-* [RISC-V](./examples/riscv)
-* [MIPS little-endian](./examples/mipsel)
+## Same-privilege function-call mode
 
-## Internal
+Linux and macOS builds provide `UserContext::run_fncall`. This mode performs the
+same register-context handoff inside a normal process, without changing CPU
+privilege levels. A cooperating user payload replaces its syscall instruction
+with a call to `syscall_fn_entry`, which returns control to `run_fncall`.
 
-Control flow on x86_64:
+This is useful for testing a userspace runtime or embedding it in a host process
+while keeping the kernel-facing control flow.
 
-![x86_64](./docs/x86_64.svg)
+## Supported targets
+
+| Architecture | Targets | Execution mode |
+| --- | --- | --- |
+| x86-64 | `x86_64-unknown-none`, `x86_64-unknown-uefi` | User/kernel transition |
+| x86-64 | `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin` | Same-privilege function call |
+| AArch64 | `aarch64-unknown-none-softfloat` | User/kernel transition |
+| AArch64 | `aarch64-unknown-linux-gnu` | Same-privilege function call |
+| RISC-V 32 | `riscv32imac-unknown-none-elf` | User/kernel transition |
+| RISC-V 64 | `riscv64imac-unknown-none-elf` | User/kernel transition |
+| MIPS little-endian | `mipsel-unknown-none` with nightly `build-std` | User/kernel transition |
+
+## Features
+
+- `ioport_bitmap`: adds an x86-64 TSS I/O-permission bitmap. It requires a
+  contiguous allocation of approximately 64 KiB.
+
+## Examples
+
+- [x86-64 UEFI kernel](./examples/uefi)
+- [RISC-V kernel](./examples/riscv)
+- [MIPS little-endian kernel](./examples/mipsel)
+
+## How the x86-64 transition works
+
+![x86-64 control flow](./docs/x86_64.svg)

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,3 +1,5 @@
+//! AArch64 register layouts and context-switch entry points.
+
 #[cfg(target_os = "linux")]
 mod fncall;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
@@ -8,84 +10,113 @@ pub use fncall::*;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
 pub use trap::*;
 
-/// Saved registers on a trap.
+/// Saved AArch64 user context used to enter and resume user code.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct UserContext {
-    /// Trap num: Source and Kind
+    /// Encoded exception source and kind.
     pub trap_num: usize,
-    /// Reserved for internal use
+    /// Reserved for the assembly frame layout.
     pub __reserved: usize,
-    /// Exception Link Register, elr_el1
+    /// Exception Link Register (`ELR_EL1`).
     pub elr: usize,
-    /// Saved Process Status Register, spsr_el1
+    /// Saved Process Status Register (`SPSR_EL1`).
     pub spsr: usize,
-    /// Stack Pointer, sp_el0
+    /// User stack pointer (`SP_EL0`).
     pub sp: usize,
-    /// Software Thread ID Register, tpidr_el0
+    /// User thread pointer (`TPIDR_EL0`).
     pub tpidr: usize,
-    /// General registers
-    /// Must be last in this struct
+    /// General-purpose registers; kept last for the assembly layout.
     pub general: GeneralRegs,
 }
 
-/// General registers
+/// AArch64 general-purpose registers.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct GeneralRegs {
+    /// General-purpose register X1.
     pub x1: usize,
+    /// General-purpose register X2.
     pub x2: usize,
+    /// General-purpose register X3.
     pub x3: usize,
+    /// General-purpose register X4.
     pub x4: usize,
+    /// General-purpose register X5.
     pub x5: usize,
+    /// General-purpose register X6.
     pub x6: usize,
+    /// General-purpose register X7.
     pub x7: usize,
+    /// Indirect result location register X8; also the Linux syscall number.
     pub x8: usize,
+    /// General-purpose register X9.
     pub x9: usize,
+    /// General-purpose register X10.
     pub x10: usize,
+    /// General-purpose register X11.
     pub x11: usize,
+    /// General-purpose register X12.
     pub x12: usize,
+    /// General-purpose register X13.
     pub x13: usize,
+    /// General-purpose register X14.
     pub x14: usize,
+    /// General-purpose register X15.
     pub x15: usize,
+    /// Intra-procedure-call scratch register X16.
     pub x16: usize,
+    /// Intra-procedure-call scratch register X17.
     pub x17: usize,
+    /// Platform register X18.
     pub x18: usize,
+    /// Callee-saved register X19.
     pub x19: usize,
+    /// Callee-saved register X20.
     pub x20: usize,
+    /// Callee-saved register X21.
     pub x21: usize,
+    /// Callee-saved register X22.
     pub x22: usize,
+    /// Callee-saved register X23.
     pub x23: usize,
+    /// Callee-saved register X24.
     pub x24: usize,
+    /// Callee-saved register X25.
     pub x25: usize,
+    /// Callee-saved register X26.
     pub x26: usize,
+    /// Callee-saved register X27.
     pub x27: usize,
+    /// Callee-saved register X28.
     pub x28: usize,
+    /// Frame pointer register X29.
     pub x29: usize,
-    pub __reserved: usize, // for alignment
+    /// Reserved alignment slot used by the assembly layout.
+    pub __reserved: usize,
+    /// Link register X30.
     pub x30: usize,
-    // put here deliberately for ease of asm
+    /// Argument and return-value register X0.
     pub x0: usize,
-    // x31 means special
 }
 
 impl UserContext {
-    /// Get number of syscall
+    /// Returns the Linux system call number from `x8`.
     pub fn get_syscall_num(&self) -> usize {
         self.general.x8
     }
 
-    /// Get return value of syscall
+    /// Returns the system call result from `x0`.
     pub fn get_syscall_ret(&self) -> usize {
         self.general.x0
     }
 
-    /// Set return value of syscall
+    /// Sets the system call result in `x0`.
     pub fn set_syscall_ret(&mut self, ret: usize) {
         self.general.x0 = ret;
     }
 
-    /// Get syscall args
+    /// Returns the six system call arguments in ABI order.
     pub fn get_syscall_args(&self) -> [usize; 6] {
         [
             self.general.x0,
@@ -97,22 +128,22 @@ impl UserContext {
         ]
     }
 
-    /// Set instruction pointer
+    /// Sets the exception return address.
     pub fn set_ip(&mut self, ip: usize) {
         self.elr = ip;
     }
 
-    /// Set stack pointer
+    /// Sets the user stack pointer.
     pub fn set_sp(&mut self, sp: usize) {
         self.sp = sp;
     }
 
-    /// Get stack pointer
+    /// Returns the user stack pointer.
     pub fn get_sp(&self) -> usize {
         self.sp
     }
 
-    /// Set tls pointer
+    /// Sets the user TLS pointer.
     pub fn set_tls(&mut self, tls: usize) {
         self.tpidr = tls;
     }

--- a/src/arch/aarch64/trap.rs
+++ b/src/arch/aarch64/trap.rs
@@ -18,7 +18,7 @@ pub unsafe fn init() {
     }
 }
 
-/// Trap frame of kernel interrupt
+/// Register frame saved when an exception enters the kernel.
 ///
 /// # Trap handler
 ///
@@ -35,20 +35,19 @@ pub unsafe fn init() {
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct TrapFrame {
-    /// Trap num: Source and Kind
+    /// Encoded exception source and kind.
     pub trap_num: usize,
-    /// Reserved for internal use
+    /// Reserved for the assembly frame layout.
     pub __reserved: usize,
-    /// Exception Link Register, elr_el1
+    /// Exception Link Register (`ELR_EL1`).
     pub elr: usize,
-    /// Saved Process Status Register, spsr_el1
+    /// Saved Process Status Register (`SPSR_EL1`).
     pub spsr: usize,
-    /// Stack Pointer, sp_el1
+    /// Kernel stack pointer (`SP_EL1`).
     pub sp: usize,
-    /// Software Thread ID Register, tpidr_el1
+    /// Kernel thread pointer (`TPIDR_EL1`).
     pub tpidr: usize,
-    /// General registers
-    /// Must be last in this struct
+    /// General-purpose registers; kept last for the assembly layout.
     pub general: GeneralRegs,
 }
 

--- a/src/arch/mipsel/mod.rs
+++ b/src/arch/mipsel/mod.rs
@@ -1,3 +1,5 @@
+//! Little-endian MIPS register layouts and context-switch entry points.
+
 mod trap;
 
 pub use trap::*;

--- a/src/arch/mipsel/trap.rs
+++ b/src/arch/mipsel/trap.rs
@@ -2,7 +2,7 @@ use core::arch::{asm, global_asm};
 
 global_asm!(include_str!("trap.S"));
 
-/// Initialize interrupt handling for the current HART.
+/// Initializes exception handling on the current processor.
 ///
 /// # Safety
 ///
@@ -27,7 +27,7 @@ pub unsafe fn init() {
     }
 }
 
-/// Trap frame of kernel interrupt
+/// Register frame saved when an exception enters the kernel.
 ///
 /// # Trap handler
 ///
@@ -44,39 +44,39 @@ pub unsafe fn init() {
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct TrapFrame {
-    /// TLS
+    /// User thread-local storage pointer.
     pub tls: usize,
-    /// Reserved for internal use
+    /// Reserved for the assembly frame layout.
     pub __reserved: usize,
-    /// CP0 Status
+    /// CP0 Status register.
     pub status: usize,
-    /// CP0 cause
+    /// CP0 Cause register.
     pub cause: usize,
-    /// CP0 epc
+    /// CP0 exception program counter.
     pub epc: usize,
-    /// CP0 vaddr
+    /// CP0 bad virtual address.
     pub vaddr: usize,
-    /// General registers
+    /// General-purpose registers.
     pub general: GeneralRegs,
 }
 
-/// Saved registers on a trap.
+/// Saved MIPS user context used to enter and resume user code.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct UserContext {
-    /// TLS
+    /// User thread-local storage pointer.
     pub tls: usize,
-    /// Reserved for internal use
+    /// Reserved for the assembly frame layout.
     pub __reserved: usize,
-    /// CP0 Status
+    /// CP0 Status register.
     pub status: usize,
-    /// CP0 cause
+    /// CP0 Cause register.
     pub cause: usize,
-    /// CP0 epc
+    /// CP0 exception program counter.
     pub epc: usize,
-    /// CP0 vaddr
+    /// CP0 bad virtual address.
     pub vaddr: usize,
-    /// General registers
+    /// General-purpose registers.
     pub general: GeneralRegs,
 }
 
@@ -96,7 +96,7 @@ impl UserContext {
     ///         sp: 0x10000,
     ///         ..Default::default()
     ///     },
-    ///     sepc: 0x1000,
+    ///     epc: 0x1000,
     ///     ..Default::default()
     /// };
     /// // go to user
@@ -109,52 +109,85 @@ impl UserContext {
     }
 }
 
-/// General registers
+/// MIPS integer registers and multiply/divide result registers.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct GeneralRegs {
+    /// High multiply/divide result register.
     pub hi: usize,
+    /// Low multiply/divide result register.
     pub lo: usize,
+    /// Assembler temporary register `$1`.
     pub at: usize,
+    /// Return value and system call number register `$2`.
     pub v0: usize,
+    /// Return value register `$3`.
     pub v1: usize,
+    /// Argument register `$4`.
     pub a0: usize,
+    /// Argument register `$5`.
     pub a1: usize,
+    /// Argument register `$6`.
     pub a2: usize,
+    /// Argument or error-indicator register `$7`.
     pub a3: usize,
+    /// Temporary register `$8`.
     pub t0: usize,
+    /// Temporary register `$9`.
     pub t1: usize,
+    /// Temporary register `$10`.
     pub t2: usize,
+    /// Temporary register `$11`.
     pub t3: usize,
+    /// Temporary register `$12`.
     pub t4: usize,
+    /// Temporary register `$13`.
     pub t5: usize,
+    /// Temporary register `$14`.
     pub t6: usize,
+    /// Temporary register `$15`.
     pub t7: usize,
+    /// Saved register `$16`.
     pub s0: usize,
+    /// Saved register `$17`.
     pub s1: usize,
+    /// Saved register `$18`.
     pub s2: usize,
+    /// Saved register `$19`.
     pub s3: usize,
+    /// Saved register `$20`.
     pub s4: usize,
+    /// Saved register `$21`.
     pub s5: usize,
+    /// Saved register `$22`.
     pub s6: usize,
+    /// Saved register `$23`.
     pub s7: usize,
+    /// Temporary register `$24`.
     pub t8: usize,
+    /// Temporary register `$25`.
     pub t9: usize,
+    /// Kernel-reserved register `$26`.
     pub k0: usize,
+    /// Kernel-reserved register `$27`.
     pub k1: usize,
+    /// Global pointer register `$28`.
     pub gp: usize,
+    /// Stack pointer register `$29`.
     pub sp: usize,
+    /// Frame pointer register `$30`.
     pub fp: usize,
+    /// Return address register `$31`.
     pub ra: usize,
 }
 
 impl UserContext {
-    /// Get number of syscall
+    /// Returns the system call number from `v0`.
     pub fn get_syscall_num(&self) -> usize {
         self.general.v0
     }
 
-    /// Get return value of syscall
+    /// Returns the n32 ABI system call result.
     pub fn get_syscall_ret(&self) -> usize {
         // MIPS n32 abi
         if self.general.a3 == 0 {
@@ -164,7 +197,7 @@ impl UserContext {
         }
     }
 
-    /// Set return value of syscall
+    /// Sets the n32 ABI system call result and error indicator.
     pub fn set_syscall_ret(&mut self, ret: usize) {
         // MIPS n32 abi
         if (ret as isize) < 0 {
@@ -176,7 +209,7 @@ impl UserContext {
         }
     }
 
-    /// Get syscall args
+    /// Returns the six system call arguments in ABI order.
     pub fn get_syscall_args(&self) -> [usize; 6] {
         [
             self.general.a0,
@@ -188,22 +221,22 @@ impl UserContext {
         ]
     }
 
-    /// Set instruction pointer
+    /// Sets the exception return address.
     pub fn set_ip(&mut self, ip: usize) {
         self.epc = ip;
     }
 
-    /// Set stack pointer
+    /// Sets the user stack pointer.
     pub fn set_sp(&mut self, sp: usize) {
         self.general.sp = sp;
     }
 
-    /// Get stack pointer
+    /// Returns the user stack pointer.
     pub fn get_sp(&self) -> usize {
         self.general.sp
     }
 
-    /// Set tls pointer
+    /// Sets the user thread-local storage pointer.
     pub fn set_tls(&mut self, tls: usize) {
         self.tls = tls;
     }

--- a/src/arch/riscv/trap.rs
+++ b/src/arch/riscv/trap.rs
@@ -46,7 +46,7 @@ pub unsafe fn init() {
     }
 }
 
-/// Trap frame of kernel interrupt
+/// Register frame saved when a trap enters the kernel.
 ///
 /// # Trap handler
 ///
@@ -63,23 +63,23 @@ pub unsafe fn init() {
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct TrapFrame {
-    /// General registers
+    /// General-purpose registers.
     pub general: GeneralRegs,
-    /// Supervisor Status
+    /// Supervisor status register (`sstatus`).
     pub sstatus: usize,
-    /// Supervisor Exception Program Counter
+    /// Supervisor exception program counter (`sepc`).
     pub sepc: usize,
 }
 
-/// Saved registers on a trap.
+/// Saved RISC-V user context used to enter and resume user code.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct UserContext {
-    /// General registers
+    /// General-purpose registers.
     pub general: GeneralRegs,
-    /// Supervisor Status
+    /// Supervisor status register (`sstatus`).
     pub sstatus: usize,
-    /// Supervisor Exception Program Counter
+    /// Supervisor exception program counter (`sepc`).
     pub sepc: usize,
 }
 
@@ -112,61 +112,93 @@ impl UserContext {
     }
 }
 
-/// General registers
+/// RISC-V integer registers in architectural order.
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct GeneralRegs {
+    /// Hard-wired zero register X0.
     pub zero: usize,
+    /// Return address register X1.
     pub ra: usize,
+    /// Stack pointer register X2.
     pub sp: usize,
+    /// Global pointer register X3.
     pub gp: usize,
+    /// Thread pointer register X4.
     pub tp: usize,
+    /// Temporary register X5.
     pub t0: usize,
+    /// Temporary register X6.
     pub t1: usize,
+    /// Temporary register X7.
     pub t2: usize,
+    /// Saved/frame pointer register X8.
     pub s0: usize,
+    /// Saved register X9.
     pub s1: usize,
+    /// Argument and return-value register X10.
     pub a0: usize,
+    /// Argument and return-value register X11.
     pub a1: usize,
+    /// Argument register X12.
     pub a2: usize,
+    /// Argument register X13.
     pub a3: usize,
+    /// Argument register X14.
     pub a4: usize,
+    /// Argument register X15.
     pub a5: usize,
+    /// Argument register X16.
     pub a6: usize,
+    /// Argument and system call number register X17.
     pub a7: usize,
+    /// Saved register X18.
     pub s2: usize,
+    /// Saved register X19.
     pub s3: usize,
+    /// Saved register X20.
     pub s4: usize,
+    /// Saved register X21.
     pub s5: usize,
+    /// Saved register X22.
     pub s6: usize,
+    /// Saved register X23.
     pub s7: usize,
+    /// Saved register X24.
     pub s8: usize,
+    /// Saved register X25.
     pub s9: usize,
+    /// Saved register X26.
     pub s10: usize,
+    /// Saved register X27.
     pub s11: usize,
+    /// Temporary register X28.
     pub t3: usize,
+    /// Temporary register X29.
     pub t4: usize,
+    /// Temporary register X30.
     pub t5: usize,
+    /// Temporary register X31.
     pub t6: usize,
 }
 
 impl UserContext {
-    /// Get number of syscall
+    /// Returns the system call number from `a7`.
     pub fn get_syscall_num(&self) -> usize {
         self.general.a7
     }
 
-    /// Get return value of syscall
+    /// Returns the system call result from `a0`.
     pub fn get_syscall_ret(&self) -> usize {
         self.general.a0
     }
 
-    /// Set return value of syscall
+    /// Sets the system call result in `a0`.
     pub fn set_syscall_ret(&mut self, ret: usize) {
         self.general.a0 = ret;
     }
 
-    /// Get syscall args
+    /// Returns the six system call arguments in ABI order.
     pub fn get_syscall_args(&self) -> [usize; 6] {
         [
             self.general.a0,
@@ -178,22 +210,22 @@ impl UserContext {
         ]
     }
 
-    /// Set instruction pointer
+    /// Sets the exception return address.
     pub fn set_ip(&mut self, ip: usize) {
         self.sepc = ip;
     }
 
-    /// Set stack pointer
+    /// Sets the user stack pointer.
     pub fn set_sp(&mut self, sp: usize) {
         self.general.sp = sp;
     }
 
-    /// Get stack pointer
+    /// Returns the user stack pointer.
     pub fn get_sp(&self) -> usize {
         self.general.sp
     }
 
-    /// Set tls pointer
+    /// Sets the user thread pointer.
     pub fn set_tls(&mut self, tls: usize) {
         self.general.tp = tls;
     }

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -43,58 +43,81 @@ pub unsafe fn init() {
     syscall::init();
 }
 
-/// User space context
+/// Saved x86-64 user context used to enter and resume user code.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct UserContext {
+    /// General-purpose registers and execution state.
     pub general: GeneralRegs,
+    /// Interrupt vector or synthetic trap number that returned control.
     pub trap_num: usize,
+    /// Error code associated with the trap.
     pub error_code: usize,
 }
 
-/// General registers
+/// x86-64 general-purpose registers and execution state.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[repr(C)]
 pub struct GeneralRegs {
+    /// Accumulator register.
     pub rax: usize,
+    /// Base register.
     pub rbx: usize,
+    /// Counter register.
     pub rcx: usize,
+    /// Data register.
     pub rdx: usize,
+    /// Source index register.
     pub rsi: usize,
+    /// Destination index register.
     pub rdi: usize,
+    /// Frame pointer register.
     pub rbp: usize,
+    /// Stack pointer register.
     pub rsp: usize,
+    /// General-purpose register R8.
     pub r8: usize,
+    /// General-purpose register R9.
     pub r9: usize,
+    /// General-purpose register R10.
     pub r10: usize,
+    /// General-purpose register R11.
     pub r11: usize,
+    /// General-purpose register R12.
     pub r12: usize,
+    /// General-purpose register R13.
     pub r13: usize,
+    /// General-purpose register R14.
     pub r14: usize,
+    /// General-purpose register R15.
     pub r15: usize,
+    /// Instruction pointer.
     pub rip: usize,
+    /// Saved processor flags.
     pub rflags: usize,
+    /// FS segment base, conventionally used as the user TLS pointer.
     pub fsbase: usize,
+    /// GS segment base.
     pub gsbase: usize,
 }
 
 impl UserContext {
-    /// Get number of syscall
+    /// Returns the system call number from `rax`.
     pub fn get_syscall_num(&self) -> usize {
         self.general.rax
     }
 
-    /// Get return value of syscall
+    /// Returns the system call result from `rax`.
     pub fn get_syscall_ret(&self) -> usize {
         self.general.rax
     }
 
-    /// Set return value of syscall
+    /// Sets the system call result in `rax`.
     pub fn set_syscall_ret(&mut self, ret: usize) {
         self.general.rax = ret;
     }
 
-    /// Get syscall args
+    /// Returns the six system call arguments in ABI order.
     pub fn get_syscall_args(&self) -> [usize; 6] {
         [
             self.general.rdi,
@@ -106,22 +129,22 @@ impl UserContext {
         ]
     }
 
-    /// Set instruction pointer
+    /// Sets the instruction pointer.
     pub fn set_ip(&mut self, ip: usize) {
         self.general.rip = ip;
     }
 
-    /// Set stack pointer
+    /// Sets the stack pointer.
     pub fn set_sp(&mut self, sp: usize) {
         self.general.rsp = sp;
     }
 
-    /// Get stack pointer
+    /// Returns the stack pointer.
     pub fn get_sp(&self) -> usize {
         self.general.rsp
     }
 
-    /// Set tls pointer
+    /// Sets the user TLS pointer in `fsbase`.
     pub fn set_tls(&mut self, tls: usize) {
         self.general.fsbase = tls;
     }

--- a/src/arch/x86_64/trap.rs
+++ b/src/arch/x86_64/trap.rs
@@ -3,7 +3,7 @@ use core::arch::global_asm;
 global_asm!(include_str!("trap.S"));
 global_asm!(include_str!(concat!(env!("OUT_DIR"), "/vector.S")));
 
-/// Trap frame of kernel interrupt
+/// Register frame saved when an interrupt or exception enters the kernel.
 ///
 /// # Trap handler
 ///
@@ -26,31 +26,50 @@ global_asm!(include_str!(concat!(env!("OUT_DIR"), "/vector.S")));
 #[derive(Debug, Default, Clone, Copy)]
 #[repr(C)]
 pub struct TrapFrame {
-    // Pushed by 'trap.S'
+    /// Accumulator register.
     pub rax: usize,
+    /// Base register.
     pub rbx: usize,
+    /// Counter register.
     pub rcx: usize,
+    /// Data register.
     pub rdx: usize,
+    /// Source index register.
     pub rsi: usize,
+    /// Destination index register.
     pub rdi: usize,
+    /// Frame pointer register.
     pub rbp: usize,
+    /// Stack pointer captured by the assembly entry code.
     pub rsp: usize,
+    /// General-purpose register R8.
     pub r8: usize,
+    /// General-purpose register R9.
     pub r9: usize,
+    /// General-purpose register R10.
     pub r10: usize,
+    /// General-purpose register R11.
     pub r11: usize,
+    /// General-purpose register R12.
     pub r12: usize,
+    /// General-purpose register R13.
     pub r13: usize,
+    /// General-purpose register R14.
     pub r14: usize,
+    /// General-purpose register R15.
     pub r15: usize,
+    /// Alignment slot reserved by the assembly frame layout.
     pub _pad: usize,
 
-    // Pushed by 'vector.S'
+    /// Interrupt vector number.
     pub trap_num: usize,
+    /// Processor-supplied or synthetic error code.
     pub error_code: usize,
 
-    // Pushed by CPU
+    /// Instruction pointer at the interrupted location.
     pub rip: usize,
+    /// Code segment selector at the interrupted location.
     pub cs: usize,
+    /// Processor flags at the interrupted location.
     pub rflags: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,33 @@
+//! Cross the user/kernel boundary through a function-like context switch.
+//!
+//! `trapframe` saves the current kernel context, enters a [`UserContext`], and
+//! returns from `UserContext::run` when the user context traps. The trap is
+//! therefore presented to kernel Rust code like the return value of an ordinary
+//! function call: inspect the updated context, handle the event, then run it
+//! again.
+//!
+//! The exact register layout and trap metadata are selected at compile time for
+//! x86-64, AArch64, RISC-V 32/64, or little-endian MIPS.
+//!
+//! On hosted x86-64 and AArch64 targets, `UserContext::run_fncall` provides a
+//! same-privilege variant for testing or embedding user code in a normal
+//! process.
+//!
+//! # Typical flow
+//!
+//! 1. Call `init` once to install the architecture's trap entry points.
+//! 2. Fill a [`UserContext`] with the initial instruction pointer, stack
+//!    pointer, and arguments.
+//! 3. Call `UserContext::run`.
+//! 4. When it returns, inspect the saved registers and trap metadata.
+//!
+//! The low-level layouts are public because kernels commonly need direct access
+//! to saved registers. They are `#[repr(C)]` and must stay synchronized with the
+//! assembly routines in this crate.
+
 #![no_std]
 #![deny(warnings)]
+#![deny(missing_docs)]
 #![cfg_attr(target_arch = "mips", feature(asm_experimental_arch))]
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## Summary

- configure docs.rs to build every rustup-supported target, including `x86_64-unknown-none`
- document every public API and enforce `missing_docs`
- rewrite the README around function-like user/kernel context switching
- enable all features in docs.rs so the x86-64 I/O-port API is included

## Validation

- generated rustdoc for all configured docs.rs targets with all features
- generated MIPS rustdoc with nightly `build-std`
- `cargo test --all-features`
- `cargo test --all-features --target x86_64-apple-darwin`