### PR TITLE
feat(aarch64): enable function-call context on macOS

### DIFF
--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -2,8 +2,8 @@
 //!
 //! # Assumption
 //!
-//! This module suppose you are running kernel on Linux with glibc,
-//! and your user program is based on musl libc.
+//! This module supposes the kernel is hosted by a Unix-like system and the
+//! user program has a writable thread-pointer area.
 //!
 //! Because we will store values in their pthread structure.
 

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,11 +1,11 @@
 //! AArch64 register layouts and context-switch entry points.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 mod fncall;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
 mod trap;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub use fncall::*;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
 pub use trap::*;


### PR DESCRIPTION
Enable the existing AArch64 function-call context switch implementation for macOS hosts. This exposes `syscall_fn_entry` and `UserContext::run_fncall`, matching the x86_64 hosted support.\n\nValidated with `cargo +nightly-2026-09-01 check --target aarch64-apple-darwin`.