### PR TITLE
ci: test aarch64 fncall on Apple Silicon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,24 @@ jobs:
       - name: Test AArch64 libos context switching
         run: cargo test --all-features
 
+  test-aarch64-macos-native:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - name: Verify Apple Silicon runner
+        run: test "$(uname -m)" = arm64
+      - name: Verify AArch64 fncall test is present
+        run: |
+          cargo test --all-features --target aarch64-apple-darwin -- --list \
+            | grep -q 'arch::fncall::tests::run_fncall: test'
+      - name: Test AArch64 function-call context switching
+        run: >-
+          cargo test --all-features --target aarch64-apple-darwin
+          arch::fncall::tests::run_fncall -- --exact
+
   test-riscv:
     runs-on: ubuntu-latest
     strategy:

--- a/src/arch/aarch64/fncall.S
+++ b/src/arch/aarch64/fncall.S
@@ -6,10 +6,6 @@
 # - tp:0  (pthread.self)       = kernel tp
 # - tp:72 (pthread.???)        = init user tp
 
-.global syscall_fn_entry
-.global syscall_fn_return
-.global syscall_fn_return_extended
-
 syscall_fn_entry:
     # save 2 registers for scratch
     stp     x0, x30, [sp, #-16] // save x0, x30 at user stack
@@ -45,7 +41,7 @@ syscall_fn_entry:
     # save floating-point and Advanced SIMD state
     sub     x4, sp, #48
     ldr     x5, [x4, #8]
-    tbz     x5, #0, syscall_fn_entry_without_fp
+    tbz     x5, #0, 9f
     stp     q0, q1, [x4, #304]
     stp     q2, q3, [x4, #336]
     stp     q4, q5, [x4, #368]
@@ -67,7 +63,7 @@ syscall_fn_entry:
     add     x5, x4, #816
     stp     w2, w3, [x5]
 
-syscall_fn_entry_without_fp:
+9:
     # skip sp and save tpidr
     mrs     x1, tpidr_el0
     str     x1, [sp, #-8]
@@ -100,11 +96,11 @@ syscall_fn_entry_without_fp:
     # extern "C" fn syscall_fn_return(&mut UserContext)
 syscall_fn_return:
     mov     x10, #0
-    b       syscall_fn_return_common
+    b       8f
 syscall_fn_return_extended:
     mov     x10, #1
-syscall_fn_return_common:
-    cbz     x10, syscall_fn_return_without_fp
+8:
+    cbz     x10, 7f
     # restore floating-point and Advanced SIMD state
     ldp     q0, q1, [x0, #304]
     ldp     q2, q3, [x0, #336]
@@ -127,7 +123,7 @@ syscall_fn_return_common:
     msr     fpcr, x1
     msr     fpsr, x2
 
-syscall_fn_return_without_fp:
+7:
     # save callee-saved registers
     stp     x29, x30, [sp, #-16]!
     stp     x27, x28, [sp, #-16]!
@@ -148,7 +144,7 @@ syscall_fn_return_without_fp:
     # pop tpidr
     ldr     x9, [x0, #5*8]  // x9 = user tp
     cbnz    x9, 1f          // if not 0, goto set
-    add     x9, x8, #72     // x9 = init user tp
+    INIT_USER_TP x9, x8     // x9 = init user tp
 1:  msr     tpidr_el0, x9   // tp = x9
     str     x0, [x9, #48]   // user_tp:48 = user context
 

--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -10,6 +10,38 @@
 use super::{UserContext, UserContextWithExtensions};
 use core::arch::global_asm;
 
+#[cfg(target_os = "linux")]
+global_asm!(
+    r#"
+.macro INIT_USER_TP dst, kernel_tp
+    add     \dst, \kernel_tp, #72
+.endm
+
+.global syscall_fn_entry
+.global syscall_fn_return
+.global syscall_fn_return_extended
+"#
+);
+
+#[cfg(target_os = "macos")]
+global_asm!(
+    r#"
+.macro INIT_USER_TP dst, kernel_tp
+    // Darwin's TSD base is in TPIDRRO_EL0. Use TSD slot 30 as the
+    // backing storage for the initial synthetic user thread pointer.
+    mrs     \dst, tpidrro_el0
+    add     \dst, \dst, #240
+.endm
+
+.global _syscall_fn_entry
+.global _syscall_fn_return
+.global _syscall_fn_return_extended
+.set _syscall_fn_entry, syscall_fn_entry
+.set _syscall_fn_return, syscall_fn_return
+.set _syscall_fn_return_extended, syscall_fn_return_extended
+"#
+);
+
 global_asm!(include_str!("fncall.S"));
 
 unsafe extern "C" {
@@ -50,6 +82,31 @@ mod tests {
     use crate::*;
     use core::arch::{asm, global_asm};
 
+    #[cfg(target_os = "linux")]
+    global_asm!(
+        r#"
+.macro LOAD_ADDRESS reg, symbol
+    adrp    \reg, \symbol
+    add     \reg, \reg, :lo12:\symbol
+.endm
+"#
+    );
+
+    #[cfg(target_os = "macos")]
+    global_asm!(
+        r#"
+.macro LOAD_ADDRESS reg, symbol
+    adrp    \reg, \symbol@GOTPAGE
+    ldr     \reg, [\reg, \symbol@GOTPAGEOFF]
+.endm
+
+.set _dump_registers, dump_registers
+.set _elr_location, elr_location
+.set RESTORED_Q0, _RESTORED_Q0
+.set UPDATED_Q0, _UPDATED_Q0
+"#
+    );
+
     #[unsafe(no_mangle)]
     static mut RESTORED_Q0: u128 = 0;
     #[unsafe(no_mangle)]
@@ -60,11 +117,9 @@ mod tests {
         r#"
 dump_registers:
     str     x9, [sp, #-16]!
-    adrp    x9, RESTORED_Q0
-    add     x9, x9, :lo12:RESTORED_Q0
+    LOAD_ADDRESS x9, RESTORED_Q0
     str     q0, [x9]
-    adrp    x9, UPDATED_Q0
-    add     x9, x9, :lo12:UPDATED_Q0
+    LOAD_ADDRESS x9, UPDATED_Q0
     ldr     q0, [x9]
     ldr     x9, [sp], #16
     stp     x30, x0, [sp, #-16]!


### PR DESCRIPTION
Run the AArch64 function-call context-switch test natively on the `macos-15` Apple Silicon runner. The job verifies the host architecture and that the targeted test is present before executing it.