### PR TITLE
fix(aarch64): preserve host FP state across fncall

### DIFF
--- a/src/arch/aarch64/fncall.S
+++ b/src/arch/aarch64/fncall.S
@@ -83,6 +83,18 @@ syscall_fn_entry:
     ldr     x1, [sp], #16
     msr     tpidr_el0, x1
 
+    # restore the host floating-point environment and the SIMD registers that
+    # are callee-saved by AAPCS64.  The user context may freely modify these,
+    # but syscall_fn_return is still an ordinary host function call as far as
+    # its Rust caller is concerned.
+    ldp     x2, x3, [sp], #16
+    msr     fpcr, x2
+    msr     fpsr, x3
+    ldp     d8, d9, [sp], #16
+    ldp     d10, d11, [sp], #16
+    ldp     d12, d13, [sp], #16
+    ldp     d14, d15, [sp], #16
+
     # load callee-saved registers
     ldp     x19, x20, [sp], #16
     ldp     x21, x22, [sp], #16
@@ -100,6 +112,33 @@ syscall_fn_return:
 syscall_fn_return_extended:
     mov     x10, #1
 8:
+    # save callee-saved registers
+    stp     x29, x30, [sp, #-16]!
+    stp     x27, x28, [sp, #-16]!
+    stp     x25, x26, [sp, #-16]!
+    stp     x23, x24, [sp, #-16]!
+    stp     x21, x22, [sp, #-16]!
+    stp     x19, x20, [sp, #-16]!
+
+    # Preserve the host floating-point environment and the low 64 bits of
+    # v8-v15, which AAPCS64 requires a function to keep intact.
+    stp     d14, d15, [sp, #-16]!
+    stp     d12, d13, [sp, #-16]!
+    stp     d10, d11, [sp, #-16]!
+    stp     d8, d9, [sp, #-16]!
+    mrs     x11, fpcr
+    mrs     x12, fpsr
+    stp     x11, x12, [sp, #-16]!
+
+    # save kernel tp
+    mrs     x8, tpidr_el0   // x8 = kernel tp
+    str     x8, [sp, #-16]!
+
+    # save kernel sp to UserContext
+    mov     x9, sp
+    orr     x9, x9, x10
+    str     x9, [x0, #8]
+
     cbz     x10, 7f
     # restore floating-point and Advanced SIMD state
     ldp     q0, q1, [x0, #304]
@@ -124,23 +163,6 @@ syscall_fn_return_extended:
     msr     fpsr, x2
 
 7:
-    # save callee-saved registers
-    stp     x29, x30, [sp, #-16]!
-    stp     x27, x28, [sp, #-16]!
-    stp     x25, x26, [sp, #-16]!
-    stp     x23, x24, [sp, #-16]!
-    stp     x21, x22, [sp, #-16]!
-    stp     x19, x20, [sp, #-16]!
-
-    # save kernel tp
-    mrs     x8, tpidr_el0   // x8 = kernel tp
-    str     x8, [sp, #-16]!
-
-    # save kernel sp to UserContext
-    mov     x9, sp
-    orr     x9, x9, x10
-    str     x9, [x0, #8]
-
     # pop tpidr
     ldr     x9, [x0, #5*8]  // x9 = user tp
     cbnz    x9, 1f          // if not 0, goto set

--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -89,6 +89,8 @@ mod tests {
     adrp    \reg, \symbol
     add     \reg, \reg, :lo12:\symbol
 .endm
+
+.global test_preserve_host_d8
 "#
     );
 
@@ -102,6 +104,7 @@ mod tests {
 
 .set _dump_registers, dump_registers
 .set _elr_location, elr_location
+.set _test_preserve_host_d8, test_preserve_host_d8
 .set RESTORED_Q0, _RESTORED_Q0
 .set UPDATED_Q0, _UPDATED_Q0
 "#
@@ -175,6 +178,24 @@ dump_registers:
 
 .global elr_location
 elr_location:
+
+// Call the extended entry point while holding a sentinel in the AAPCS64
+// callee-saved d8 register. Return the observed value through x1 while
+// preserving the real caller's d8.
+test_preserve_host_d8:
+    stp     x19, x20, [sp, #-32]!
+    str     x30, [sp, #16]
+    str     d8, [sp, #24]
+    mov     x19, x1
+    mov     x20, x2
+    fmov    d8, x20
+    bl      syscall_fn_return_extended
+    fmov    x9, d8
+    str     x9, [x19]
+    ldr     d8, [sp, #24]
+    ldr     x30, [sp, #16]
+    ldp     x19, x20, [sp], #32
+    ret
 "#
     );
 
@@ -183,6 +204,11 @@ elr_location:
         unsafe extern "C" {
             fn dump_registers();
             fn elr_location();
+            fn test_preserve_host_d8(
+                context: &mut UserContextWithExtensions,
+                observed: &mut u64,
+                sentinel: u64,
+            );
         }
         let mut stack = [0u8; 0x1000];
         let general = GeneralRegs {
@@ -259,10 +285,13 @@ elr_location:
         };
         let initial_q0 = 0x1122_3344_5566_7788_99aa_bbcc_ddee_ff00;
         cx.fp_simd.registers[0] = initial_q0;
-        cx.run_fncall();
+        let initial_host_d8 = 0x1357_9bdf_2468_ace0_u64;
+        let mut restored_host_d8 = 0;
+        unsafe { test_preserve_host_d8(&mut cx, &mut restored_host_d8, initial_host_d8) };
         let restored_q0 = unsafe { core::ptr::addr_of!(RESTORED_Q0).read_volatile() };
         assert_eq!(restored_q0, initial_q0);
         assert_eq!(cx.fp_simd.registers[0], UPDATED_Q0);
+        assert_eq!(restored_host_d8, initial_host_d8);
         // check restored registers
         let general_dump = unsafe { *(cx.sp as *const GeneralRegs) };
         assert_eq!(


### PR DESCRIPTION
The hosted AArch64 fncall path restored the guest FP/SIMD context before entering user code, but did not preserve the host ABI state. In particular, d8-d15 are callee-saved under AAPCS64, so returning to Rust with guest values can corrupt live host values and crash larger callers such as zCore.

Preserve d8-d15 plus FPCR/FPSR on the kernel stack across each fncall. Add a regression assertion that places a sentinel in d8 around the extended context switch.

This is needed by rcore-os/zCore#419 on native AArch64 Linux and macOS.