### PR TITLE
test(aarch64): cover extended guest x18 restore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,12 +141,19 @@ jobs:
         run: test "$(uname -m)" = arm64
       - name: Verify AArch64 fncall test is present
         run: |
-          cargo test --all-features --target aarch64-apple-darwin -- --list \
-            | grep -q 'arch::fncall::tests::run_fncall_extended_restores_guest_x18: test'
+          cargo test --all-features --target aarch64-apple-darwin -- --list > /tmp/tests.txt
+          grep -q 'arch::fncall::tests::run_fncall_extended_restores_guest_x18: test' /tmp/tests.txt
       - name: Test AArch64 function-call context switching
-        run: >-
-          cargo test --release --all-features --target aarch64-apple-darwin
-          arch::fncall::tests:: -- --test-threads=1
+        run: |
+          cargo test --release --all-features --target aarch64-apple-darwin --no-run
+          test_bin=$(find target/aarch64-apple-darwin/release/deps -type f -perm +111 -name 'trapframe-*' | head -1)
+          lldb --batch \
+            -o run \
+            -k 'thread backtrace all' \
+            -k 'register read x0 x1 x8 x18 x30 sp pc' \
+            -k 'disassemble --start-address "$pc-32" --count 20' \
+            -- "$test_bin" \
+            'arch::fncall::tests::run_fncall' --exact
 
   test-riscv:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,16 +144,9 @@ jobs:
           cargo test --all-features --target aarch64-apple-darwin -- --list > /tmp/tests.txt
           grep -q 'arch::fncall::tests::run_fncall_extended_restores_guest_x18: test' /tmp/tests.txt
       - name: Test AArch64 function-call context switching
-        run: |
-          cargo test --release --all-features --target aarch64-apple-darwin --no-run
-          test_bin=$(find target/aarch64-apple-darwin/release/deps -type f -perm +111 -name 'trapframe-*' | head -1)
-          lldb --batch \
-            -o run \
-            -k 'thread backtrace all' \
-            -k 'register read x0 x1 x8 x18 x30 sp pc' \
-            -k 'disassemble --start-address "$pc-32" --count 20' \
-            -- "$test_bin" \
-            'arch::fncall::tests::run_fncall' --exact
+        run: >-
+          cargo test --release --all-features --target aarch64-apple-darwin
+          arch::fncall::tests:: -- --test-threads=1
 
   test-riscv:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
           cargo test --all-features -- --list \
             | grep -q 'arch::fncall::tests::run_fncall: test'
       - name: Test AArch64 libos context switching
-        run: cargo test --all-features
+        run: cargo test --all-features -- --test-threads=1
 
   test-aarch64-macos-native:
     runs-on: macos-15
@@ -142,11 +142,11 @@ jobs:
       - name: Verify AArch64 fncall test is present
         run: |
           cargo test --all-features --target aarch64-apple-darwin -- --list \
-            | grep -q 'arch::fncall::tests::run_fncall: test'
+            | grep -q 'arch::fncall::tests::run_fncall_extended_restores_guest_x18: test'
       - name: Test AArch64 function-call context switching
         run: >-
-          cargo test --all-features --target aarch64-apple-darwin
-          arch::fncall::tests::run_fncall -- --exact
+          cargo test --release --all-features --target aarch64-apple-darwin
+          arch::fncall::tests:: -- --test-threads=1
 
   test-riscv:
     runs-on: ubuntu-latest

--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -194,6 +194,7 @@ mod tests {
 .endm
 
 .global test_preserve_host_state
+.global observe_guest_x18
 "#
     );
 
@@ -208,6 +209,8 @@ mod tests {
 .set _dump_registers, dump_registers
 .set _elr_location, elr_location
 .set _test_preserve_host_state, test_preserve_host_state
+.set _observe_guest_x18, observe_guest_x18
+.set _observe_guest_x18_return, observe_guest_x18_return
 .set RESTORED_Q0, _RESTORED_Q0
 .set UPDATED_Q0, _UPDATED_Q0
 "#
@@ -307,6 +310,14 @@ test_preserve_host_state:
     ldp     x21, x30, [sp, #16]
     ldp     x19, x20, [sp], #64
     ret
+
+// Observe the guest x18 value restored by the direct Rust entry path.
+observe_guest_x18:
+    mov     x0, x18
+    bl      syscall_fn_entry
+.global observe_guest_x18_return
+observe_guest_x18_return:
+    brk     #0
 "#
     );
 
@@ -470,5 +481,33 @@ test_preserve_host_state:
             }
         );
         assert_eq!(cx.elr, elr_location as *const () as usize);
+    }
+
+    #[test]
+    fn run_fncall_extended_restores_guest_x18() {
+        unsafe extern "C" {
+            fn observe_guest_x18();
+            fn observe_guest_x18_return();
+        }
+
+        let mut stack = [0u8; 0x1000];
+        let mut guest_tls = [0usize; 32];
+        let guest_x18 = 0x1020_3040_5060_7080;
+        let mut context = UserContextWithExtensions {
+            elr: observe_guest_x18 as *const () as usize,
+            sp: stack.as_mut_ptr() as usize + stack.len(),
+            tpidr: unsafe { guest_tls.as_mut_ptr().add(8) } as usize,
+            general: GeneralRegs {
+                x18: guest_x18,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        context.run_fncall();
+
+        assert_eq!(context.general.x0, guest_x18);
+        assert_eq!(context.general.x18, guest_x18);
+        assert_eq!(context.elr, observe_guest_x18_return as *const () as usize);
     }
 }

--- a/src/arch/aarch64/fncall.rs
+++ b/src/arch/aarch64/fncall.rs
@@ -333,7 +333,10 @@ observe_guest_x18_return:
                 x18_sentinel: u64,
             );
         }
-        let mut stack = [0u8; 0x1000];
+        #[repr(align(16))]
+        struct AlignedStack([u8; 0x1000]);
+
+        let mut stack = AlignedStack([0; 0x1000]);
         let mut guest_tls = [0usize; 32];
         let initial_guest_tp = unsafe { guest_tls.as_mut_ptr().add(8) } as usize;
         let general = GeneralRegs {
@@ -372,7 +375,7 @@ observe_guest_x18_return:
         };
         let base = UserContext {
             general,
-            sp: stack.as_mut_ptr() as usize + 0x1000,
+            sp: stack.0.as_mut_ptr() as usize + stack.0.len(),
             elr: dump_registers as *const () as usize,
             tpidr: initial_guest_tp,
             ..Default::default()
@@ -490,12 +493,15 @@ observe_guest_x18_return:
             fn observe_guest_x18_return();
         }
 
-        let mut stack = [0u8; 0x1000];
+        #[repr(align(16))]
+        struct AlignedStack([u8; 0x1000]);
+
+        let mut stack = AlignedStack([0; 0x1000]);
         let mut guest_tls = [0usize; 32];
         let guest_x18 = 0x1020_3040_5060_7080;
         let mut context = UserContextWithExtensions {
             elr: observe_guest_x18 as *const () as usize,
-            sp: stack.as_mut_ptr() as usize + stack.len(),
+            sp: stack.0.as_mut_ptr() as usize + stack.0.len(),
             tpidr: unsafe { guest_tls.as_mut_ptr().add(8) } as usize,
             general: GeneralRegs {
                 x18: guest_x18,

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -12,7 +12,7 @@ pub use trap::*;
 
 /// Saved AArch64 user context used to enter and resume user code.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[repr(C, align(16))]
 pub struct UserContext {
     /// Encoded exception source and kind.
     pub trap_num: usize,


### PR DESCRIPTION
Add a direct `UserContextWithExtensions::run_fncall` regression test that verifies the guest platform register is restored. This matches zCore’s actual AArch64 LibOS entry path and complements the existing assembly-wrapper host-state test.